### PR TITLE
Fixed a few white text on white background areas in the chat area of individual issues

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -410,6 +410,10 @@ issues-table table.table.table-striped.table-hover.table-responsive.table-conden
 .row.issue-details h1 {
   margin-left: 15px;
 }
+/* Issues chat window and input styling */
+.messages[_ngcontent-c1] > p[_ngcontent-c1] {
+  color: #000;
+}
 .chat-window .col-xs-12 .panel .panel-footer {
   border-radius: 0px 0px 5px 5px;
 }
@@ -424,10 +428,23 @@ issues-table table.table.table-striped.table-hover.table-responsive.table-conden
   padding-left: 1px;
   padding-top: 5px !important;
 }
+.chat-window .col-xs-12 .panel .panel-footer .input-group .input-group-btn {
+  padding-left: 1px;
+  padding-top: 5px !important;
+}
 .chat-window .col-xs-12 .panel .panel-footer .input-group .form-control {
   height: 38px;
+  width: 315px;
   margin-top: 5px;
   background-color: rgba(255, 255, 255, .08);
+}
+.chat-window .col-xs-12 .panel .panel-footer .input-group #btn-input {
+  width: 315px;
+}
+.chat-window .col-xs-12 .panel .panel-footer .input-group #btn-input:focus {
+  color: #000;
+  width: 315px;
+  background-color: rgba(255, 255, 255, .0);
 }
 .chat-window .col-xs-12 .panel .panel-footer .input-group .input-group-btn .btn-primary {
   background-color: rgba(204, 123, 25, 1) !important;


### PR DESCRIPTION
Fxed white text on white background in issue message history.  Fixed white text on white background when in an existing issue and adding a new chat comment.  On input element focus, text is now black.  TODO: when the 'Send' button is clicked and the message is submitted, the input loses focus and goes back to white text on white background.  I believe this is due to the 'Send' button being contained within the input-group element along with the input element.  So even though the input itself loses focus the input-group still has focus and so it still shows the white background.  I don't have time to fix this right now, but it should be fixed in the future.